### PR TITLE
treat like tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,12 +8,13 @@
 <link rel="icon" href="icon.svg">
 <link rel="canonical" href="https://ryanve.github.io/sluj">
 
-<header>
+<h1>
   <a class="bae-vine bold big" href="https://ryanve.github.io/sluj">sluj</a>
-  is a
-  <a class="bae-vein bold" href="https://jekyllrb.com/docs/permalinks/#global"><code>permalink</code></a>
-  sampler project
-</header>
+  <span class="bob lil calm">
+    <a class="bae-vein bold" href="https://jekyllrb.com/docs/permalinks/#global"><code>permalink</code></a>
+    sampler project
+  </span>
+</h1>
 
 <nav aria-label="surf">
   <ul>

--- a/project.css
+++ b/project.css
@@ -1,18 +1,13 @@
 html { font: 2em/2 sans-serif }
 body { margin: 1em }
+h1 { margin: 0 }
 a { padding: .1em }
 
 .calm { font-weight: 400 }
 .bold { font-weight: 700 }
-
-.big {
-  font-size: 2rem;
-  vertical-align: sub;
-}
-
-.bob {
-  display: block;
-}
+.lil { font-size: 1rem }
+.big { font-size: 2rem }
+.bob { display: block }
 
 ::selection {
   background: lime;


### PR DESCRIPTION
code homepage header with `h1` but style like tagline

## 2 reasons

- this ups the lighthouse a11y score from 96% to 100%
- this keeps the `sluj` link in the same spot repowide