### PR TITLE
try slug again

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
-permalink: pretty
+permalink: /:slug
 plugins:
   - jekyll-sitemap


### PR DESCRIPTION
**EDIT** after checking 3x3

### these `permalink` settings 

- `/:slug`
- `pretty`
- `none`

### behave the same for these URLs

- https://ryanve.github.io/sluj/deep/file :ok:
- https://ryanve.github.io/sluj/deep/file.html :ok:
- https://ryanve.github.io/sluj/deep/file/ **404**